### PR TITLE
Set naming information

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 This [FMU](https://fmi-standard.org/) is able to write binary OSI SensorData trace files.
 The folder the trace files shall be written to has to be passed as FMI parameter _trace_path_.
-The trace file writer is build according to the [ASAM Open simulation Interface (OSI)](https://github.com/OpenSimulationInterface/open-simulation-interface) and the [OSI Sensor Model Packaging (OSMP)](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging) examples.
+The trace file writer is build according to
+the [ASAM Open simulation Interface (OSI)](https://github.com/OpenSimulationInterface/open-simulation-interface) and
+the [OSI Sensor Model Packaging (OSMP)](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging) examples.
+
+## FMI Parameters
+
+| Parameter        | Description                                                                                                                                                                                                                                           |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| trace_path       | Path, where to put the generated trace file                                                                                                                                                                                                           |
+| protobuf_version | Protobuf version, with which the OSI messages are serialized as string, e.g. "2112" for v21.12 (see [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html)) |
+| custom_name      | Custom name as a suffix for the trace file name (see [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html)                                                 |
 
 ## Installation
 

--- a/src/OSMP.cpp
+++ b/src/OSMP.cpp
@@ -157,7 +157,7 @@ fmi2Status OSMP::DoEnterInitializationMode()
 
 fmi2Status OSMP::DoExitInitializationMode()
 {
-    trace_file_writer_.Init(FmiTracePath());
+    trace_file_writer_.Init(FmiTracePath(), FmiProtobufVersion(), FmiCustomName());
 
     return fmi2OK;
 }

--- a/src/OSMP.cpp
+++ b/src/OSMP.cpp
@@ -182,6 +182,7 @@ fmi2Status OSMP::DoCalc(fmi2Real current_communication_point, fmi2Real communica
 
 fmi2Status OSMP::DoTerm()
 {
+    trace_file_writer_.Term();
     return fmi2OK;
 }
 

--- a/src/OSMP.h
+++ b/src/OSMP.h
@@ -56,7 +56,9 @@
 
 /* String Variables */
 #define FMI_STRING_TRACE_PATH_IDX 0
-#define FMI_STRING_LAST_IDX FMI_STRING_TRACE_PATH_IDX
+#define FMI_STRING_PROTOBUF_VERSION_IDX 1
+#define FMI_STRING_CUSTOM_NAME_IDX 2
+#define FMI_STRING_LAST_IDX FMI_STRING_CUSTOM_NAME_IDX
 #define FMI_STRING_VARS (FMI_STRING_LAST_IDX+1)
 
 #include <cstdarg>
@@ -229,6 +231,14 @@ class OSMP
     void SetFmiTracePath(string value)
     {
         string_vars_[FMI_STRING_TRACE_PATH_IDX] = value;
+    }
+    string FmiProtobufVersion()
+    {
+        return string_vars_[FMI_STRING_PROTOBUF_VERSION_IDX];
+    }
+    string FmiCustomName()
+    {
+        return string_vars_[FMI_STRING_CUSTOM_NAME_IDX];
     }
 
     /* Protocol Buffer Accessors */

--- a/src/TraceFileWriter.cpp
+++ b/src/TraceFileWriter.cpp
@@ -26,6 +26,8 @@ void TraceFileWriter::Init(std::string trace_path)
 
 osi3::SensorData TraceFileWriter::Step(osi3::SensorData sensor_data)
 {
+    num_frames_++;
+    osi_version_ = std::to_string(sensor_data.version().version_major()) + std::to_string(sensor_data.version().version_minor()) + std::to_string(sensor_data.version().version_patch());
     typedef unsigned int MessageSizeT;
     std::ofstream bin_file(trace_path_ + trace_file_name_, std::ios::binary | std::ios_base::app);
 
@@ -56,8 +58,14 @@ void TraceFileWriter::SetFileName()
     detl = localtime(&curr_time);
     strftime(buf, 20, "%Y%m%dT%H%M%SZ", detl);
 
-    std::string start_time = std::string(buf);
+    start_time = std::string(buf);
 
-    trace_file_name_ = start_time + "_sd_350_300_0000.osi";
+    trace_file_name_ = start_time + "_sd_tmp.osi";
+}
+void TraceFileWriter::Term()
+{
+    std::string filename_tmp = trace_path_ + trace_file_name_;
+    std::string filename_final = trace_path_ + start_time + "_sd_" + osi_version_ + "_" + protobuf_version_ + "_" + std::to_string(num_frames_) + ".osi";
+    std::rename(filename_tmp.c_str(), filename_final.c_str());
 }
 

--- a/src/TraceFileWriter.cpp
+++ b/src/TraceFileWriter.cpp
@@ -14,13 +14,15 @@
 #include "osi_sensordata.pb.h"
 #include "osi_sensorview.pb.h"
 
-void TraceFileWriter::Init(std::string trace_path)
+void TraceFileWriter::Init(std::string trace_path, std::string protobuf_version, std::string custom_name)
 {
     trace_path_ = std::move(trace_path);
     if (!trace_path_.empty() && trace_path_.back() != '/')
     {
         trace_path_ += '/';
     }
+    protobuf_version_ = protobuf_version;
+    custom_name_ = custom_name;
     SetFileName();
 }
 
@@ -58,14 +60,19 @@ void TraceFileWriter::SetFileName()
     detl = localtime(&curr_time);
     strftime(buf, 20, "%Y%m%dT%H%M%SZ", detl);
 
-    start_time = std::string(buf);
+    start_time_ = std::string(buf);
 
-    trace_file_name_ = start_time + "_sd_tmp.osi";
+    trace_file_name_ = start_time_ + "_sd_tmp.osi";
 }
 void TraceFileWriter::Term()
 {
     std::string filename_tmp = trace_path_ + trace_file_name_;
-    std::string filename_final = trace_path_ + start_time + "_sd_" + osi_version_ + "_" + protobuf_version_ + "_" + std::to_string(num_frames_) + ".osi";
+    std::string filename_final = trace_path_ + start_time_ + "_sd_" + osi_version_ + "_" + protobuf_version_ + "_" + std::to_string(num_frames_);
+    if (!custom_name_.empty())
+    {
+        filename_final += "_" + custom_name_;
+    }
+    filename_final += ".osi";
     std::rename(filename_tmp.c_str(), filename_final.c_str());
 }
 

--- a/src/TraceFileWriter.h
+++ b/src/TraceFileWriter.h
@@ -13,7 +13,7 @@
 class TraceFileWriter
 {
   public:
-    void Init(std::string trace_path);
+    void Init(std::string trace_path, std::string protobuf_version, std::string custom_name);
     osi3::SensorData Step(osi3::SensorData sensor_data);
     void Term();
 
@@ -21,10 +21,11 @@ class TraceFileWriter
 
     std::string trace_path_;
     std::string trace_file_name_;
-    std::string start_time;
+    std::string start_time_;
     int num_frames_ = 0;
     std::string osi_version_;
-    std::string protobuf_version_ = "2112";
+    std::string protobuf_version_;
+    std::string custom_name_;
 
     void SetFileName();
 

--- a/src/TraceFileWriter.h
+++ b/src/TraceFileWriter.h
@@ -12,12 +12,12 @@
 
 class TraceFileWriter
 {
-  public:
+ public:
     void Init(std::string trace_path, std::string protobuf_version, std::string custom_name);
     osi3::SensorData Step(osi3::SensorData sensor_data);
     void Term();
 
-  private:
+ private:
 
     std::string trace_path_;
     std::string trace_file_name_;
@@ -34,7 +34,7 @@ class TraceFileWriter
     static ofstream private_log_file;
 #endif
 
-    static void FmiVerboseLogGlobal(const char* format, ...)
+    static void FmiVerboseLogGlobal(const char *format, ...)
     {
 #ifdef VERBOSE_FMI_LOGGING
 #ifdef PRIVATE_LOG_PATH
@@ -58,7 +58,7 @@ class TraceFileWriter
 #endif
     }
 
-    void InternalLog(const char* category, const char* format, va_list arg)
+    void InternalLog(const char *category, const char *format, va_list arg)
     {
 #if defined(PRIVATE_LOG_PATH) || defined(PUBLIC_LOGGING)
         char buffer[1024];
@@ -84,7 +84,7 @@ class TraceFileWriter
 #endif
     }
 
-    void FmiVerboseLog(const char* format, ...)
+    void FmiVerboseLog(const char *format, ...)
     {
 #if defined(VERBOSE_FMI_LOGGING) && (defined(PRIVATE_LOG_PATH) || defined(PUBLIC_LOGGING))
         va_list ap;
@@ -95,7 +95,7 @@ class TraceFileWriter
     }
 
     /* Normal Logging */
-    void NormalLog(const char* category, const char* format, ...)
+    void NormalLog(const char *category, const char *format, ...)
     {
 #if defined(PRIVATE_LOG_PATH) || defined(PUBLIC_LOGGING)
         va_list ap;

--- a/src/TraceFileWriter.h
+++ b/src/TraceFileWriter.h
@@ -15,11 +15,16 @@ class TraceFileWriter
   public:
     void Init(std::string trace_path);
     osi3::SensorData Step(osi3::SensorData sensor_data);
+    void Term();
 
   private:
 
     std::string trace_path_;
     std::string trace_file_name_;
+    std::string start_time;
+    int num_frames_ = 0;
+    std::string osi_version_;
+    std::string protobuf_version_ = "2112";
 
     void SetFileName();
 

--- a/src/modelDescription.in.xml
+++ b/src/modelDescription.in.xml
@@ -51,6 +51,12 @@
     <ScalarVariable name="trace_path" valueReference="0" causality="parameter" variability="fixed">
       <String start=""/>
     </ScalarVariable>
+    <ScalarVariable name="protobuf_version" valueReference="1" causality="parameter" variability="fixed">
+      <String start=""/>
+    </ScalarVariable>
+    <ScalarVariable name="custom_name" valueReference="2" causality="parameter" variability="fixed">
+      <String start=""/>
+    </ScalarVariable>
   </ModelVariables>
   <ModelStructure>
     <Outputs>


### PR DESCRIPTION
Set information according to the [trace file naming scheme](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html).

Fixes #2, #3 and #4 

- [x] OSI version from input sensor_data
- [x] Protobuf version from FMI parameter
- [x] Number of frames
- [x] Custom trace name from FMI parameter