### PR TITLE
15 incorporate asam osi utilities

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
     - name: Checkout Model
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Cache Dependencies
       id: cache-depends

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,11 @@ jobs:
       working-directory: protobuf-21.12
       run: sudo make install && sudo ldconfig
 
+    - name: Install `libzstd` and `liblz4`
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libzstd-dev liblz4-dev
+
     - name: Prepare C++ Build
       run: mkdir build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,8 @@ jobs:
       working-directory: build
       run: cmake --build .
 
+    - name: Upload FMU Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: sl-5-6-osi-trace-file-writer.fmu
+        path: build/sl-5-6-osi-trace-file-writer.fmu

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -10,10 +10,10 @@ jobs:
   cpp-linter:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Model
-      uses: actions/checkout@v3
+    - name: Checkout Tool
+      uses: actions/checkout@v4
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Cache Dependencies
       id: cache-depends

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: markdown-lint
       uses: articulate/actions-markdownlint@v1
       with:

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - uses: enarx/spdx@master
       with:
         licenses: Apache-2.0 BSD-3-Clause BSD-2-Clause MIT MPL-2.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/open-simulation-interface"]
 	path = lib/open-simulation-interface
 	url = https://github.com/OpenSimulationInterface/open-simulation-interface.git
+[submodule "lib/asam-osi-utilities"]
+	path = lib/asam-osi-utilities
+	url = https://github.com/Lichtblick-Suite/asam-osi-utilities.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,23 @@ project(sl-5-6-osi-trace-file-writer)
 
 set(OSMPVERSION "1.2.0" CACHE STRING "OSMP Version String")
 
+# OSI
 add_subdirectory(lib/open-simulation-interface)
+list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/lib/open-simulation-interface)
 get_directory_property(OSI_VERSION_MAJOR DIRECTORY lib/open-simulation-interface DEFINITION VERSION_MAJOR)
 get_directory_property(OSI_VERSION_MINOR DIRECTORY lib/open-simulation-interface DEFINITION VERSION_MINOR)
 get_directory_property(OSI_VERSION_PATCH DIRECTORY lib/open-simulation-interface DEFINITION VERSION_PATCH)
 set(OSIVERSION "${OSI_VERSION_MAJOR}.${OSI_VERSION_MINOR}.${OSI_VERSION_PATCH}")
 
+# fmi
 include_directories(lib/fmi2/headers)
+
+# asam-osi-utilities
+set(USE_EXTERNAL_OSI ON)
+add_subdirectory(lib/asam-osi-utilities EXCLUDE_FROM_ALL)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/asam-osi-utilities/include)
+set_target_properties(OSIUtilities PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 
 set(FMU_INSTALL_DIR "${CMAKE_BINARY_DIR}" CACHE PATH "Target directory for generated FMU")
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # SL-5-6 OSI Trace File Writer
 
-This [FMU](https://fmi-standard.org/) is able to write binary OSI SensorData trace files.
-The folder the trace files shall be written to has to be passed as FMI parameter _trace_path_.
+This OSI Trace File Writer is a [FMU](https://fmi-standard.org/) designed to generate trace files from multiple OSI message types including `SensorData`, `SensorView`, and `GroundTruth`. 
+It offers different output format options to meet various needs.
+
 The trace file writer is build according to
 the [ASAM Open simulation Interface (OSI)](https://github.com/OpenSimulationInterface/open-simulation-interface) and
 the [OSI Sensor Model Packaging (OSMP)](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging) examples.
 
 ## FMI Parameters
 
-| Parameter        | Description                                                                                                                                                                                                                                           |
-|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| trace_path       | Path, where to put the generated trace file                                                                                                                                                                                                           |
-| protobuf_version | Protobuf version, with which the OSI messages are serialized as string, e.g. "2112" for v21.12 (see [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html)) |
-| custom_name      | Custom name as a suffix for the trace file name (see [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html))                                                |
-| type             | OSI message type string according to the [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html)                                                             |
+| Parameter        | Description                                                                                                                                                                                                                                                               |
+|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| trace_path       | Path, where to put the generated trace file                                                                                                                                                                                                                               |
+| protobuf_version | Protobuf version, with which the OSI messages are serialized as string, e.g. "2112" for v21.12 (see [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html))                     |
+| custom_name      | Custom name as a suffix for the trace file name (see [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html))                                                                    |
+| message_type     | OSI message type string according to the [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html). <br>Currently supports: SensorData (sd), SensorView (sv), and GroundTruth (gt) |
+| file_format      | Format of the output trace file. Allowed values: mcap, osi, or txth                                                                                                                                                                                                      |
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SL-5-6 OSI Trace File Writer
 
-This OSI Trace File Writer is a [FMU](https://fmi-standard.org/) designed to generate trace files from multiple OSI message types including `SensorData`, `SensorView`, and `GroundTruth`. 
+This OSI Trace File Writer is a [FMU](https://fmi-standard.org/) designed to generate trace files from multiple OSI message types including `SensorData`, `SensorView`, and `GroundTruth`.
 It offers different output format options to meet various needs.
 
 The trace file writer is build according to
@@ -16,7 +16,6 @@ the [OSI Sensor Model Packaging (OSMP)](https://github.com/OpenSimulationInterfa
 | custom_name      | Custom name as a suffix for the trace file name (see [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html))                                                                    |
 | message_type     | OSI message type string according to the [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html). <br>Currently supports: SensorData (sd), SensorView (sv), and GroundTruth (gt) |
 | file_format      | Format of the output trace file. Allowed values: mcap, osi, or txth                                                                                                                                                                                                      |
-
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,17 @@ Install `protobuf` (at least version 3.0.0):
 sudo apt-get install libprotobuf-dev protobuf-compiler
 ```
 
+Install `libzstd` and `liblz4`:
+
+```bash
+sudo apt-get install libzstd-dev liblz4-dev
+```
+
 ### Clone with submodules
 
 ```bash
-git clone https://github.com/openMSL/sl-5-6-osi-trace-file-writer.git
+git clone --recurse-submodules https://github.com/openMSL/sl-5-6-osi-trace-file-writer.git
 cd sl-5-6-osi-trace-file-writer
-git submodule update --init
 ```
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the [OSI Sensor Model Packaging (OSMP)](https://github.com/OpenSimulationInterfa
 | protobuf_version | Protobuf version, with which the OSI messages are serialized as string, e.g. "2112" for v21.12 (see [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html))                     |
 | custom_name      | Custom name as a suffix for the trace file name (see [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html))                                                                    |
 | message_type     | OSI message type string according to the [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html). <br>Currently supports: SensorData (sd), SensorView (sv), and GroundTruth (gt) |
-| file_format      | Format of the output trace file. Allowed values: mcap, osi, or txth                                                                                                                                                                                                      |
+| file_format      | Format of the output trace file. Allowed values: mcap, osi, or txth                                                                                                                                                                                                       |
 
 ## Installation
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(LINK_WITH_SHARED_OSI OFF CACHE BOOL "Link FMU with shared OSI library instead of statically linking")
 set(PUBLIC_LOGGING OFF CACHE BOOL "Enable logging via FMI logger")
@@ -21,6 +21,8 @@ if(LINK_WITH_SHARED_OSI)
 else()
 	target_link_libraries(sl-5-6-osi-trace-file-writer open_simulation_interface_pic)
 endif()
+
+target_link_libraries(sl-5-6-osi-trace-file-writer OSIUtilities)
 
 if(WIN32)
 	if(CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/src/OSMP.cpp
+++ b/src/OSMP.cpp
@@ -187,9 +187,6 @@ fmi2Status OSMP::DoExitInitializationMode()
 
 fmi2Status OSMP::DoCalc(fmi2Real current_communication_point, fmi2Real communication_step_size, fmi2Boolean no_set_fmu_state_prior_to_current_pointfmi_2_component)
 {
-
-    osi3::SensorData current_in;
-
     if (const void* buffer = DecodeIntegerToPointer(integer_vars_[FMI_INTEGER_OSI_IN_BASEHI_IDX], integer_vars_[FMI_INTEGER_OSI_IN_BASELO_IDX]);
         !trace_file_writer_.Step(buffer, integer_vars_[FMI_INTEGER_OSI_IN_SIZE_IDX]))
     {

--- a/src/OSMP.cpp
+++ b/src/OSMP.cpp
@@ -158,14 +158,12 @@ fmi2Status OSMP::DoEnterInitializationMode()
 fmi2Status OSMP::DoExitInitializationMode()
 {
     // get file format from parameter
-    const std::map<std::string, FileFormat> FORMAT_MAP = {
-        {"osi", FileFormat::OSI},
-        {"mcap", FileFormat::MCAP},
-        {"txth", FileFormat::TXTH}
-    };
-
-    // Get lowercase format string
     std::string file_format_parameter = FmiFileFormat();
+    if (file_format_parameter.empty()) {
+        NormalLog("OSI","No file format specified, assuming .osi as default");
+        file_format_parameter = "osi";
+    }
+    // Get lowercase format string
     std::transform(file_format_parameter.begin(), file_format_parameter.end(),
                    file_format_parameter.begin(), ::tolower);
 
@@ -175,12 +173,17 @@ fmi2Status OSMP::DoExitInitializationMode()
     }
 
     // determine format using map
+    const std::map<std::string, FileFormat> FORMAT_MAP = {
+        {"osi", FileFormat::OSI},
+        {"mcap", FileFormat::MCAP},
+        {"txth", FileFormat::TXTH}
+    };
     const auto format_map_it = FORMAT_MAP.find(file_format_parameter);
     if (format_map_it == FORMAT_MAP.end()) {
         std::cerr << "Unknown trace file format: " << FmiFileFormat() << std::endl;
         return fmi2Error;
     }
-    trace_file_writer_.Init(FmiTracePath(), FmiProtobufVersion(), FmiCustomName(), FmiMessageType(), format_map_it->second); // TODO change
+    trace_file_writer_.Init(FmiTracePath(), FmiProtobufVersion(), FmiCustomName(), FmiMessageType(), format_map_it->second);
 
     return fmi2OK;
 }

--- a/src/OSMP.cpp
+++ b/src/OSMP.cpp
@@ -54,7 +54,7 @@ ofstream COSMPDummySensor::private_log_file;
  * ProtocolBuffer Accessors
  */
 
-void *DecodeIntegerToPointer(fmi2Integer hi, fmi2Integer lo)
+void* DecodeIntegerToPointer(fmi2Integer hi, fmi2Integer lo)
 {
 #if PTRDIFF_MAX == INT64_MAX
     union Addrconv
@@ -68,7 +68,7 @@ void *DecodeIntegerToPointer(fmi2Integer hi, fmi2Integer lo)
     } myaddr;
     myaddr.base.lo = lo;
     myaddr.base.hi = hi;
-    return reinterpret_cast<void *>(myaddr.address);
+    return reinterpret_cast<void*>(myaddr.address);
 #elif PTRDIFF_MAX == INT32_MAX
     return reinterpret_cast<void*>(lo);
 #else
@@ -76,7 +76,7 @@ void *DecodeIntegerToPointer(fmi2Integer hi, fmi2Integer lo)
 #endif
 }
 
-void EncodePointerToInteger(const void *ptr, fmi2Integer &hi, fmi2Integer &lo)
+void EncodePointerToInteger(const void* ptr, fmi2Integer& hi, fmi2Integer& lo)
 {
 #if PTRDIFF_MAX == INT64_MAX
     union Addrconv
@@ -99,11 +99,11 @@ void EncodePointerToInteger(const void *ptr, fmi2Integer &hi, fmi2Integer &lo)
 #endif
 }
 
-bool OSMP::GetFmiSensorDataIn(osi3::SensorData &data)
+bool OSMP::GetFmiSensorDataIn(osi3::SensorData& data)
 {
     if (integer_vars_[FMI_INTEGER_OSI_IN_SIZE_IDX] > 0)
     {
-        void *buffer = DecodeIntegerToPointer(integer_vars_[FMI_INTEGER_OSI_IN_BASEHI_IDX], integer_vars_[FMI_INTEGER_OSI_IN_BASELO_IDX]);
+        void* buffer = DecodeIntegerToPointer(integer_vars_[FMI_INTEGER_OSI_IN_BASEHI_IDX], integer_vars_[FMI_INTEGER_OSI_IN_BASELO_IDX]);
         NormalLog("OSMP", "Got %08X %08X, reading from %p ...", integer_vars_[FMI_INTEGER_OSI_IN_BASEHI_IDX], integer_vars_[FMI_INTEGER_OSI_IN_BASELO_IDX], buffer);
         data.ParseFromArray(buffer, integer_vars_[FMI_INTEGER_OSI_IN_SIZE_IDX]);
         return true;
@@ -119,25 +119,25 @@ fmi2Status OSMP::DoInit()
 {
 
     /* Booleans */
-    for (int &boolean_var : boolean_vars_)
+    for (int& boolean_var : boolean_vars_)
     {
         boolean_var = fmi2False;
     }
 
     /* Integers */
-    for (int &integer_var : integer_vars_)
+    for (int& integer_var : integer_vars_)
     {
         integer_var = 0;
     }
 
     /* Reals */
-    for (double &real_var : real_vars_)
+    for (double& real_var : real_vars_)
     {
         real_var = 0.0;
     }
 
     /* Strings */
-    for (auto &string_var : string_vars_)
+    for (auto& string_var : string_vars_)
     {
         string_var = "";
     }
@@ -159,27 +159,25 @@ fmi2Status OSMP::DoExitInitializationMode()
 {
     // get file format from parameter
     std::string file_format_parameter = FmiFileFormat();
-    if (file_format_parameter.empty()) {
-        NormalLog("OSI","No file format specified, assuming .osi as default");
+    if (file_format_parameter.empty())
+    {
+        NormalLog("OSI", "No file format specified, assuming .osi as default");
         file_format_parameter = "osi";
     }
     // Get lowercase format string
-    std::transform(file_format_parameter.begin(), file_format_parameter.end(),
-                   file_format_parameter.begin(), ::tolower);
+    std::transform(file_format_parameter.begin(), file_format_parameter.end(), file_format_parameter.begin(), ::tolower);
 
     // Remove leading dot if present
-    if (!file_format_parameter.empty() && file_format_parameter[0] == '.') {
+    if (!file_format_parameter.empty() && file_format_parameter[0] == '.')
+    {
         file_format_parameter.erase(0, 1);
     }
 
     // determine format using map
-    const std::map<std::string, FileFormat> FORMAT_MAP = {
-        {"osi", FileFormat::OSI},
-        {"mcap", FileFormat::MCAP},
-        {"txth", FileFormat::TXTH}
-    };
+    const std::map<std::string, FileFormat> FORMAT_MAP = {{"osi", FileFormat::OSI}, {"mcap", FileFormat::MCAP}, {"txth", FileFormat::TXTH}};
     const auto format_map_it = FORMAT_MAP.find(file_format_parameter);
-    if (format_map_it == FORMAT_MAP.end()) {
+    if (format_map_it == FORMAT_MAP.end())
+    {
         std::cerr << "Unknown trace file format: " << FmiFileFormat() << std::endl;
         return fmi2Error;
     }
@@ -217,7 +215,7 @@ OSMP::OSMP(fmi2String theinstance_name,
            fmi2Type thefmu_type,
            fmi2String thefmu_guid,
            fmi2String thefmu_resource_location,
-           const fmi2CallbackFunctions *thefunctions,
+           const fmi2CallbackFunctions* thefunctions,
            fmi2Boolean thevisible,
            fmi2Boolean thelogging_on)
     : instance_name_(theinstance_name),
@@ -247,15 +245,18 @@ fmi2Status OSMP::SetDebugLogging(fmi2Boolean thelogging_on, size_t n_categories,
             if (0 == strcmp(categories[i], "FMI"))
             {
                 logging_categories_.insert("FMI");
-            } else if (0 == strcmp(categories[i], "OSMP"))
+            }
+            else if (0 == strcmp(categories[i], "OSMP"))
             {
                 logging_categories_.insert("OSMP");
-            } else if (0 == strcmp(categories[i], "OSI"))
+            }
+            else if (0 == strcmp(categories[i], "OSI"))
             {
                 logging_categories_.insert("OSI");
             }
         }
-    } else
+    }
+    else
     {
         logging_categories_.clear();
         logging_categories_.insert("FMI");
@@ -269,11 +270,11 @@ fmi2Component OSMP::Instantiate(fmi2String instance_name,
                                 fmi2Type fmu_type,
                                 fmi2String fmu_guid,
                                 fmi2String fmu_resource_location,
-                                const fmi2CallbackFunctions *functions,
+                                const fmi2CallbackFunctions* functions,
                                 fmi2Boolean visible,
                                 fmi2Boolean logging_on)
 {
-    auto *myc = new OSMP(instance_name, fmu_type, fmu_guid, fmu_resource_location, functions, visible, logging_on);
+    auto* myc = new OSMP(instance_name, fmu_type, fmu_guid, fmu_resource_location, functions, visible, logging_on);
 
     if (myc == nullptr)
     {
@@ -310,7 +311,7 @@ fmi2Component OSMP::Instantiate(fmi2String instance_name,
                         visible,
                         logging_on,
                         myc);
-    return (fmi2Component) myc;
+    return (fmi2Component)myc;
 }
 
 fmi2Status OSMP::SetupExperiment(fmi2Boolean tolerance_defined, fmi2Real tolerance, fmi2Real start_time, fmi2Boolean stop_time_defined, fmi2Real stop_time)
@@ -367,7 +368,8 @@ fmi2Status OSMP::GetReal(const fmi2ValueReference vr[], size_t nvr, fmi2Real val
         if (vr[i] < FMI_REAL_VARS)
         {
             value[i] = real_vars_[vr[i]];
-        } else
+        }
+        else
         {
             return fmi2Error;
         }
@@ -383,7 +385,8 @@ fmi2Status OSMP::GetInteger(const fmi2ValueReference vr[], size_t nvr, fmi2Integ
         if (vr[i] < FMI_INTEGER_VARS)
         {
             value[i] = integer_vars_[vr[i]];
-        } else
+        }
+        else
         {
             return fmi2Error;
         }
@@ -399,7 +402,8 @@ fmi2Status OSMP::GetBoolean(const fmi2ValueReference vr[], size_t nvr, fmi2Boole
         if (vr[i] < FMI_BOOLEAN_VARS)
         {
             value[i] = boolean_vars_[vr[i]];
-        } else
+        }
+        else
         {
             return fmi2Error;
         }
@@ -415,7 +419,8 @@ fmi2Status OSMP::GetString(const fmi2ValueReference vr[], size_t nvr, fmi2String
         if (vr[i] < FMI_STRING_VARS)
         {
             value[i] = string_vars_[vr[i]].c_str();
-        } else
+        }
+        else
         {
             return fmi2Error;
         }
@@ -431,7 +436,8 @@ fmi2Status OSMP::SetReal(const fmi2ValueReference vr[], size_t nvr, const fmi2Re
         if (vr[i] < FMI_REAL_VARS)
         {
             real_vars_[vr[i]] = value[i];
-        } else
+        }
+        else
         {
             return fmi2Error;
         }
@@ -447,7 +453,8 @@ fmi2Status OSMP::SetInteger(const fmi2ValueReference vr[], size_t nvr, const fmi
         if (vr[i] < FMI_INTEGER_VARS)
         {
             integer_vars_[vr[i]] = value[i];
-        } else
+        }
+        else
         {
             return fmi2Error;
         }
@@ -463,7 +470,8 @@ fmi2Status OSMP::SetBoolean(const fmi2ValueReference vr[], size_t nvr, const fmi
         if (vr[i] < FMI_BOOLEAN_VARS)
         {
             boolean_vars_[vr[i]] = value[i];
-        } else
+        }
+        else
         {
             return fmi2Error;
         }
@@ -479,7 +487,8 @@ fmi2Status OSMP::SetString(const fmi2ValueReference vr[], size_t nvr, const fmi2
         if (vr[i] < FMI_STRING_VARS)
         {
             string_vars_[vr[i]] = value[i];
-        } else
+        }
+        else
         {
             return fmi2Error;
         }
@@ -493,19 +502,19 @@ fmi2Status OSMP::SetString(const fmi2ValueReference vr[], size_t nvr, const fmi2
 
 extern "C" {
 
-FMI2_Export const char *fmi2GetTypesPlatform()
+FMI2_Export const char* fmi2GetTypesPlatform()
 {
     return fmi2TypesPlatform;
 }
 
-FMI2_Export const char *fmi2GetVersion()
+FMI2_Export const char* fmi2GetVersion()
 {
     return fmi2Version;
 }
 
 FMI2_Export fmi2Status fmi2SetDebugLogging(fmi2Component c, fmi2Boolean logging_on, size_t n_categories, const fmi2String categories[])
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->SetDebugLogging(logging_on, n_categories, categories);
 }
 
@@ -516,7 +525,7 @@ FMI2_Export fmi2Component fmi2Instantiate(fmi2String instance_name,
                                           fmi2Type fmu_type,
                                           fmi2String fmu_guid,
                                           fmi2String fmu_resource_location,
-                                          const fmi2CallbackFunctions *functions,
+                                          const fmi2CallbackFunctions* functions,
                                           fmi2Boolean visible,
                                           fmi2Boolean logging_on)
 {
@@ -526,19 +535,19 @@ FMI2_Export fmi2Component fmi2Instantiate(fmi2String instance_name,
 FMI2_Export fmi2Status
 fmi2SetupExperiment(fmi2Component c, fmi2Boolean tolerance_defined, fmi2Real tolerance, fmi2Real start_time, fmi2Boolean stop_time_defined, fmi2Real stop_time)
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->SetupExperiment(tolerance_defined, tolerance, start_time, stop_time_defined, stop_time);
 }
 
 FMI2_Export fmi2Status fmi2EnterInitializationMode(fmi2Component c)
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->EnterInitializationMode();
 }
 
 FMI2_Export fmi2Status fmi2ExitInitializationMode(fmi2Component c)
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->ExitInitializationMode();
 }
 
@@ -547,25 +556,25 @@ FMI2_Export fmi2Status fmi2DoStep(fmi2Component c,
                                   fmi2Real communication_step_size,
                                   fmi2Boolean no_set_fmu_state_prior_to_current_pointfmi2_component)
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->DoStep(current_communication_point, communication_step_size, no_set_fmu_state_prior_to_current_pointfmi2_component);
 }
 
 FMI2_Export fmi2Status fmi2Terminate(fmi2Component c)
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->Terminate();
 }
 
 FMI2_Export fmi2Status fmi2Reset(fmi2Component c)
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->Reset();
 }
 
 FMI2_Export void fmi2FreeInstance(fmi2Component c)
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     myc->FreeInstance();
     delete myc;
 }
@@ -575,56 +584,56 @@ FMI2_Export void fmi2FreeInstance(fmi2Component c)
  */
 FMI2_Export fmi2Status fmi2GetReal(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Real value[])
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->GetReal(vr, nvr, value);
 }
 
 FMI2_Export fmi2Status fmi2GetInteger(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Integer value[])
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->GetInteger(vr, nvr, value);
 }
 
 FMI2_Export fmi2Status fmi2GetBoolean(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Boolean value[])
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->GetBoolean(vr, nvr, value);
 }
 
 FMI2_Export fmi2Status fmi2GetString(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2String value[])
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->GetString(vr, nvr, value);
 }
 
 FMI2_Export fmi2Status fmi2SetReal(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Real value[])
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->SetReal(vr, nvr, value);
 }
 
 FMI2_Export fmi2Status fmi2SetInteger(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[])
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->SetInteger(vr, nvr, value);
 }
 
 FMI2_Export fmi2Status fmi2SetBoolean(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[])
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->SetBoolean(vr, nvr, value);
 }
 
 FMI2_Export fmi2Status fmi2SetString(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2String value[])
 {
-    auto *myc = (OSMP *) c;
+    auto* myc = (OSMP*)c;
     return myc->SetString(vr, nvr, value);
 }
 
 /*
  * Unsupported Features (FMUState, Derivatives, Async DoStep, Status Enquiries)
  */
-FMI2_Export fmi2Status fmi2GetFMUstate(fmi2Component c, fmi2FMUstate *fmu_state)
+FMI2_Export fmi2Status fmi2GetFMUstate(fmi2Component c, fmi2FMUstate* fmu_state)
 {
     return fmi2Error;
 }
@@ -634,12 +643,12 @@ FMI2_Export fmi2Status fmi2SetFMUstate(fmi2Component c, fmi2FMUstate fmu_state)
     return fmi2Error;
 }
 
-FMI2_Export fmi2Status fmi2FreeFMUstate(fmi2Component c, fmi2FMUstate *fmu_state)
+FMI2_Export fmi2Status fmi2FreeFMUstate(fmi2Component c, fmi2FMUstate* fmu_state)
 {
     return fmi2Error;
 }
 
-FMI2_Export fmi2Status fmi2SerializedFMUstateSize(fmi2Component c, fmi2FMUstate fmu_state, size_t *size)
+FMI2_Export fmi2Status fmi2SerializedFMUstateSize(fmi2Component c, fmi2FMUstate fmu_state, size_t* size)
 {
     return fmi2Error;
 }
@@ -649,7 +658,7 @@ FMI2_Export fmi2Status fmi2SerializeFMUstate(fmi2Component c, fmi2FMUstate fmu_s
     return fmi2Error;
 }
 
-FMI2_Export fmi2Status fmi2DeSerializeFMUstate(fmi2Component c, const fmi2Byte serialized_state[], size_t size, fmi2FMUstate *fmu_state)
+FMI2_Export fmi2Status fmi2DeSerializeFMUstate(fmi2Component c, const fmi2Byte serialized_state[], size_t size, fmi2FMUstate* fmu_state)
 {
     return fmi2Error;
 }
@@ -680,27 +689,27 @@ FMI2_Export fmi2Status fmi2CancelStep(fmi2Component c)
     return fmi2OK;
 }
 
-FMI2_Export fmi2Status fmi2GetStatus(fmi2Component c, const fmi2StatusKind s, fmi2Status *value)
+FMI2_Export fmi2Status fmi2GetStatus(fmi2Component c, const fmi2StatusKind s, fmi2Status* value)
 {
     return fmi2Discard;
 }
 
-FMI2_Export fmi2Status fmi2GetRealStatus(fmi2Component c, const fmi2StatusKind s, fmi2Real *value)
+FMI2_Export fmi2Status fmi2GetRealStatus(fmi2Component c, const fmi2StatusKind s, fmi2Real* value)
 {
     return fmi2Discard;
 }
 
-FMI2_Export fmi2Status fmi2GetIntegerStatus(fmi2Component c, const fmi2StatusKind s, fmi2Integer *value)
+FMI2_Export fmi2Status fmi2GetIntegerStatus(fmi2Component c, const fmi2StatusKind s, fmi2Integer* value)
 {
     return fmi2Discard;
 }
 
-FMI2_Export fmi2Status fmi2GetBooleanStatus(fmi2Component c, const fmi2StatusKind s, fmi2Boolean *value)
+FMI2_Export fmi2Status fmi2GetBooleanStatus(fmi2Component c, const fmi2StatusKind s, fmi2Boolean* value)
 {
     return fmi2Discard;
 }
 
-FMI2_Export fmi2Status fmi2GetStringStatus(fmi2Component c, const fmi2StatusKind s, fmi2String *value)
+FMI2_Export fmi2Status fmi2GetStringStatus(fmi2Component c, const fmi2StatusKind s, fmi2String* value)
 {
     return fmi2Discard;
 }

--- a/src/OSMP.h
+++ b/src/OSMP.h
@@ -61,7 +61,7 @@
 #define FMI_STRING_MESSAGE_TYPE_IDX 3
 #define FMI_STRING_FILE_FORMAT_IDX 4
 #define FMI_STRING_LAST_IDX FMI_STRING_FILE_FORMAT_IDX
-#define FMI_STRING_VARS (FMI_STRING_LAST_IDX+1)
+#define FMI_STRING_VARS (FMI_STRING_LAST_IDX + 1)
 
 #include <cstdarg>
 #include <fstream>
@@ -80,13 +80,13 @@ using namespace std;
 /* FMU Class */
 class OSMP
 {
- public:
+  public:
     /* FMI2 Interface mapped to C++ */
     OSMP(fmi2String theinstance_name,
          fmi2Type thefmu_type,
          fmi2String thefmu_guid,
          fmi2String thefmu_resource_location,
-         const fmi2CallbackFunctions *thefunctions,
+         const fmi2CallbackFunctions* thefunctions,
          fmi2Boolean thevisible,
          fmi2Boolean thelogging_on);
     fmi2Status SetDebugLogging(fmi2Boolean thelogging_on, size_t n_categories, const fmi2String categories[]);
@@ -94,7 +94,7 @@ class OSMP
                                      fmi2Type fmu_type,
                                      fmi2String fmu_guid,
                                      fmi2String fmu_resource_location,
-                                     const fmi2CallbackFunctions *functions,
+                                     const fmi2CallbackFunctions* functions,
                                      fmi2Boolean visible,
                                      fmi2Boolean logging_on);
     fmi2Status SetupExperiment(fmi2Boolean tolerance_defined, fmi2Real tolerance, fmi2Real start_time, fmi2Boolean stop_time_defined, fmi2Real stop_time);
@@ -113,7 +113,7 @@ class OSMP
     fmi2Status SetBoolean(const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[]);
     fmi2Status SetString(const fmi2ValueReference vr[], size_t nvr, const fmi2String value[]);
 
- protected:
+  protected:
     /* Internal Implementation */
     fmi2Status DoInit();
     fmi2Status DoStart(fmi2Boolean tolerance_defined, fmi2Real tolerance, fmi2Real start_time, fmi2Boolean stop_time_defined, fmi2Real stop_time);
@@ -128,7 +128,7 @@ class OSMP
     static ofstream private_log_file;
 #endif
 
-    static void FmiVerboseLogGlobal(const char *format, ...)
+    static void FmiVerboseLogGlobal(const char* format, ...)
     {
 #ifdef VERBOSE_FMI_LOGGING
 #ifdef PRIVATE_LOG_PATH
@@ -152,7 +152,7 @@ class OSMP
 #endif
     }
 
-    void InternalLog(const char *category, const char *format, va_list arg)
+    void InternalLog(const char* category, const char* format, va_list arg)
     {
 #if defined(PRIVATE_LOG_PATH) || defined(PUBLIC_LOGGING)
         char buffer[1024];
@@ -178,7 +178,7 @@ class OSMP
 #endif
     }
 
-    void FmiVerboseLog(const char *format, ...)
+    void FmiVerboseLog(const char* format, ...)
     {
 #if defined(VERBOSE_FMI_LOGGING) && (defined(PRIVATE_LOG_PATH) || defined(PUBLIC_LOGGING))
         va_list ap;
@@ -189,7 +189,7 @@ class OSMP
     }
 
     /* Normal Logging */
-    void NormalLog(const char *category, const char *format, ...)
+    void NormalLog(const char* category, const char* format, ...)
     {
 #if defined(PRIVATE_LOG_PATH) || defined(PUBLIC_LOGGING)
         va_list ap;
@@ -199,7 +199,7 @@ class OSMP
 #endif
     }
 
- private:
+  private:
     /* Members */
     string instance_name_;
     fmi2Type fmu_type_;
@@ -218,39 +218,15 @@ class OSMP
     TraceFileWriter trace_file_writer_;
 
     /* Simple Accessors */
-    fmi2Boolean FmiValid()
-    {
-        return boolean_vars_[FMI_BOOLEAN_VALID_IDX];
-    }
-    void SetFmiValid(fmi2Boolean value)
-    {
-        boolean_vars_[FMI_BOOLEAN_VALID_IDX] = value;
-    }
-    string FmiTracePath()
-    {
-        return string_vars_[FMI_STRING_TRACE_PATH_IDX];
-    }
-    void SetFmiTracePath(string value)
-    {
-        string_vars_[FMI_STRING_TRACE_PATH_IDX] = value;
-    }
-    string FmiProtobufVersion()
-    {
-        return string_vars_[FMI_STRING_PROTOBUF_VERSION_IDX];
-    }
-    string FmiCustomName()
-    {
-        return string_vars_[FMI_STRING_CUSTOM_NAME_IDX];
-    }
-    string FmiMessageType()
-    {
-        return string_vars_[FMI_STRING_MESSAGE_TYPE_IDX];
-    }
-    string FmiFileFormat()
-    {
-        return string_vars_[FMI_STRING_FILE_FORMAT_IDX];
-    }
+    fmi2Boolean FmiValid() { return boolean_vars_[FMI_BOOLEAN_VALID_IDX]; }
+    void SetFmiValid(fmi2Boolean value) { boolean_vars_[FMI_BOOLEAN_VALID_IDX] = value; }
+    string FmiTracePath() { return string_vars_[FMI_STRING_TRACE_PATH_IDX]; }
+    void SetFmiTracePath(string value) { string_vars_[FMI_STRING_TRACE_PATH_IDX] = value; }
+    string FmiProtobufVersion() { return string_vars_[FMI_STRING_PROTOBUF_VERSION_IDX]; }
+    string FmiCustomName() { return string_vars_[FMI_STRING_CUSTOM_NAME_IDX]; }
+    string FmiMessageType() { return string_vars_[FMI_STRING_MESSAGE_TYPE_IDX]; }
+    string FmiFileFormat() { return string_vars_[FMI_STRING_FILE_FORMAT_IDX]; }
 
     /* Protocol Buffer Accessors */
-    bool GetFmiSensorDataIn(osi3::SensorData &data);
+    bool GetFmiSensorDataIn(osi3::SensorData& data);
 };

--- a/src/OSMP.h
+++ b/src/OSMP.h
@@ -58,8 +58,9 @@
 #define FMI_STRING_TRACE_PATH_IDX 0
 #define FMI_STRING_PROTOBUF_VERSION_IDX 1
 #define FMI_STRING_CUSTOM_NAME_IDX 2
-#define FMI_STRING_TYPE_IDX 3
-#define FMI_STRING_LAST_IDX FMI_STRING_TYPE_IDX
+#define FMI_STRING_MESSAGE_TYPE_IDX 3
+#define FMI_STRING_FILE_FORMAT_IDX 4
+#define FMI_STRING_LAST_IDX FMI_STRING_FILE_FORMAT_IDX
 #define FMI_STRING_VARS (FMI_STRING_LAST_IDX+1)
 
 #include <cstdarg>
@@ -241,9 +242,13 @@ class OSMP
     {
         return string_vars_[FMI_STRING_CUSTOM_NAME_IDX];
     }
-    string FmiType()
+    string FmiMessageType()
     {
-        return string_vars_[FMI_STRING_TYPE_IDX];
+        return string_vars_[FMI_STRING_MESSAGE_TYPE_IDX];
+    }
+    string FmiFileFormat()
+    {
+        return string_vars_[FMI_STRING_FILE_FORMAT_IDX];
     }
 
     /* Protocol Buffer Accessors */

--- a/src/TraceFileWriter.cpp
+++ b/src/TraceFileWriter.cpp
@@ -10,48 +10,33 @@
 #include <ctime>
 #include <fstream>
 #include <utility>
+#include "filesystem"
 
 #include "osi_sensordata.pb.h"
 #include "osi_sensorview.pb.h"
 
-void TraceFileWriter::Init(std::string trace_path, std::string protobuf_version, std::string custom_name, std::string type)
+#include "osi-utilities/tracefile/writer/SingleChannelBinaryTraceFileWriter.h"
+#include "osi-utilities/tracefile/writer/MCAPTraceFileWriter.h"
+#include "osi-utilities/tracefile/writer/TXTHTraceFileWriter.h"
+
+
+void TraceFileWriter::Init(const std::string& trace_path, std::string protobuf_version, std::string custom_name, std::string message_type, FileFormat file_format)
 {
-    trace_path_ = std::move(trace_path);
-    if (!trace_path_.empty() && trace_path_.back() != '/')
-    {
-        trace_path_ += '/';
-    }
+    path_trace_folder_ = std::filesystem::path(trace_path);
     protobuf_version_ = std::move(protobuf_version);
-    custom_name_ = std::move(custom_name);
-    type_ = std::move(type);
+    custom_name_ = std::move(custom_name); // might be empty
+    type_ = std::move(message_type);
+    file_format_ = file_format;
     SetFileName();
+    SetupWriter();
+    SetupDeserializedWriterFunction();
 }
 
-osi3::SensorData TraceFileWriter::Step(osi3::SensorData sensor_data)
+
+bool TraceFileWriter::Step(const void * data, int size)
 {
     num_frames_++;
-    osi_version_ =
-        std::to_string(sensor_data.version().version_major()) + std::to_string(sensor_data.version().version_minor()) + std::to_string(sensor_data.version().version_patch());
-    typedef unsigned int MessageSizeT;
-    std::ofstream bin_file(trace_path_ + trace_file_name_, std::ios::binary | std::ios_base::app);
-
-    std::string osi_msg_string_only = sensor_data.SerializeAsString();
-    MessageSizeT message_size = osi_msg_string_only.size();
-    char character[4];
-    memcpy(character, (char*)&message_size, sizeof(MessageSizeT));
-
-    std::string osi_msg_string;
-    osi_msg_string += character[0];
-    osi_msg_string += character[1];
-    osi_msg_string += character[2];
-    osi_msg_string += character[3];
-    osi_msg_string += osi_msg_string_only;
-
-    bin_file.write(osi_msg_string.c_str(), static_cast<long>(osi_msg_string.length()));
-    bin_file.close();
-    osi_msg_string.clear();
-
-    return sensor_data;
+    return serialized_writer_function_(data, size);
 }
 
 void TraceFileWriter::SetFileName()
@@ -61,25 +46,129 @@ void TraceFileWriter::SetFileName()
     time(&curr_time);
     const tm* date_time = localtime(&curr_time);
     strftime(buf, 20, "%Y%m%dT%H%M%SZ", date_time);
-
     start_time_ = std::string(buf);
 
-    trace_file_name_ = start_time_ + "_" + type_;
+    auto trace_file_name = start_time_ + "_" + type_;
     if (!custom_name_.empty())
     {
-        trace_file_name_ += "_" + custom_name_;
+        trace_file_name += "_" + custom_name_;
     }
-    trace_file_name_ += ".osi";
+
+    trace_file_name += kFileNameMessageTypeMap.at(file_format_);
+
+    path_trace_temp_ = path_trace_folder_ / trace_file_name;
 }
 
-void TraceFileWriter::Term()
+
+void TraceFileWriter::SetupDeserializedWriterFunction() {
+    if (type_ == "sv") {
+        setupForMessageType<osi3::SensorView>();
+    }
+    else if (type_ == "sd") {
+        setupForMessageType<osi3::SensorData>();
+    }
+    else if (type_ == "gt") {
+        setupForMessageType<osi3::GroundTruth>();
+    }
+    else {
+        throw std::runtime_error("Unknown message type: " + type_);
+    }
+}
+
+template<typename T>
+void TraceFileWriter::setupForMessageType() {
+    if (file_format_ == FileFormat::MCAP) {
+        auto mcap_writer = dynamic_cast<osi3::MCAPTraceFileWriter*>(writer_.get());
+
+
+        writer_function_consecutive_ = [mcap_writer](const void* data, int size) {
+            T msg;
+            msg.ParseFromArray(data, size);
+            return mcap_writer->WriteMessage(msg, "sl-5-6-osi-trace-file-writer");
+        };
+    }
+    else if (file_format_ == FileFormat::OSI) {
+        auto binary_writer = dynamic_cast<osi3::SingleChannelBinaryTraceFileWriter*>(writer_.get());
+        writer_function_consecutive_ = [binary_writer](const void* data, int size) {
+            T msg;
+            msg.ParseFromArray(data, size);
+            return binary_writer->WriteMessage(msg);
+        };
+    }
+    else if (file_format_ == FileFormat::TXTH) {
+        auto txth_writer = dynamic_cast<osi3::TXTHTraceFileWriter*>(writer_.get());
+        writer_function_consecutive_ = [txth_writer](const void* data, int size) {
+            T msg;
+            msg.ParseFromArray(data, size);
+            return txth_writer->WriteMessage(msg);
+        };
+    }
+
+    // for the first time we receive a message, we need to extract the OSI version to add
+    // it to the mcap channel metadata (and thus create the channel on the first message)
+    // and add the OSI version the trace file name in the termination step
+    serialized_writer_function_ = [this](const void* data, int size) {
+        T msg;
+        msg.ParseFromArray(data, size);
+        auto version = msg.version();
+        this->osi_version_ = std::to_string(version.version_major()) + std::to_string(version.version_minor()) + std::to_string(version.version_patch());
+        // create mcap channel if mcap reader
+        if (this->file_format_ == FileFormat::MCAP)
+        {
+            auto mcap_writer = dynamic_cast<osi3::MCAPTraceFileWriter*>(writer_.get());
+            std::unordered_map<std::string, std::string> channel_metadata = {
+                {"net.asam.osi.trace.channel.description", "Channel added via openMSL sl-5-6-osi-trace-file-writer"},
+                {"net.asam.osi.trace.channel.osi_version", // in the current implementation of asam-osi-utilities this will be overwritten. This must be changed in the asam-osi-utilities library
+                 std::to_string(version.version_major()) + "." + std::to_string(version.version_minor()) + "." + std::to_string(version.version_patch())}};
+            mcap_writer->AddChannel("sl-5-6-osi-trace-file-writer", T::descriptor(), channel_metadata);
+        }
+        // while this is the first call, we still need to write the data to the file
+        auto write_success = this->writer_function_consecutive_(data, size);
+        // replace the writer function for the next calls
+        this->serialized_writer_function_ = this->writer_function_consecutive_;
+        return write_success;
+    };
+}
+
+
+void TraceFileWriter::SetupWriter()
 {
-    const std::string filename_tmp = trace_path_ + trace_file_name_;
-    std::string filename_final = trace_path_ + start_time_ + "_" + type_ + "_" + osi_version_ + "_" + protobuf_version_ + "_" + std::to_string(num_frames_);
+    if (file_format_ == FileFormat::MCAP) {
+            auto writer = std::make_unique<osi3::MCAPTraceFileWriter>();
+            writer->Open(path_trace_temp_);
+            writer->AddFileMetadata(osi3::MCAPTraceFileWriter::PrepareRequiredFileMetadata());
+            writer_ = std::move(writer);
+        }
+    else if (file_format_ == FileFormat::OSI)
+        {
+            auto writer = std::make_unique<osi3::SingleChannelBinaryTraceFileWriter>();
+            writer->Open(path_trace_temp_);
+            writer_ = std::move(writer);
+        }
+    else if (file_format_ == FileFormat::TXTH)
+        {
+            auto writer = std::make_unique<osi3::TXTHTraceFileWriter>();
+            writer->Open(path_trace_temp_);
+            writer_ = std::move(writer);
+        }
+    else
+    {
+    throw std::runtime_error("Unknown file format");
+    }
+}
+
+
+void TraceFileWriter::Term() const
+{
+    writer_->Close();
+
+    // rename file based on number of frames
+    std::filesystem::path path_trace_final_ = path_trace_folder_ /( start_time_ + "_" + type_ + "_" + osi_version_ + "_" + protobuf_version_ + "_" + std::to_string(num_frames_));
     if (!custom_name_.empty())
     {
-        filename_final += "_" + custom_name_;
+        path_trace_final_ += "_" + custom_name_;
     }
-    filename_final += ".osi";
-    std::rename(filename_tmp.c_str(), filename_final.c_str());
+    path_trace_final_ += kFileNameMessageTypeMap.at(file_format_);
+
+    std::filesystem::rename(path_trace_temp_, path_trace_final_);
 }

--- a/src/TraceFileWriter.h
+++ b/src/TraceFileWriter.h
@@ -15,20 +15,20 @@
 
 enum class FileFormat : u_int8_t
 {
-    kUnknown = 0,       /**< unknown file format (error */
-    MCAP,               /**< .mcap trace file format */
-    OSI,                /**< .osi trace file format*/
-    TXTH,               /**< .txth trace file format */
+    kUnknown = 0, /**< unknown file format (error */
+    MCAP,         /**< .mcap trace file format */
+    OSI,          /**< .osi trace file format*/
+    TXTH,         /**< .txth trace file format */
 };
 
 class TraceFileWriter
 {
- public:
-   void Init(const std::string& trace_path, std::string protobuf_version, std::string custom_name, std::string message_type, FileFormat file_format);
-    bool Step(const void * data, int size);
+  public:
+    void Init(const std::string& trace_path, std::string protobuf_version, std::string custom_name, std::string message_type, FileFormat file_format);
+    bool Step(const void* data, int size);
     void Term() const;
 
- private:
+  private:
     FileFormat file_format_ = FileFormat::kUnknown;
     std::unique_ptr<osi3::TraceFileWriter> writer_;
     std::function<bool(const void*, int)> serialized_writer_function_;
@@ -49,16 +49,16 @@ class TraceFileWriter
     void SetupWriter();
 
     const std::unordered_map<FileFormat, std::string> kFileNameMessageTypeMap = {{FileFormat::kUnknown, ".unknown"},
-                                                                                {FileFormat::MCAP, ".mcap"},
-                                                                                {FileFormat::OSI, ".osi"},
-                                                                                {FileFormat::TXTH, ".txth"}};
+                                                                                 {FileFormat::MCAP, ".mcap"},
+                                                                                 {FileFormat::OSI, ".osi"},
+                                                                                 {FileFormat::TXTH, ".txth"}};
 
     /* Private File-based Logging just for Debugging */
 #ifdef PRIVATE_LOG_PATH
     static ofstream private_log_file;
 #endif
 
-    static void FmiVerboseLogGlobal(const char *format, ...)
+    static void FmiVerboseLogGlobal(const char* format, ...)
     {
 #ifdef VERBOSE_FMI_LOGGING
 #ifdef PRIVATE_LOG_PATH
@@ -82,7 +82,7 @@ class TraceFileWriter
 #endif
     }
 
-    void InternalLog(const char *category, const char *format, va_list arg)
+    void InternalLog(const char* category, const char* format, va_list arg)
     {
 #if defined(PRIVATE_LOG_PATH) || defined(PUBLIC_LOGGING)
         char buffer[1024];
@@ -108,7 +108,7 @@ class TraceFileWriter
 #endif
     }
 
-    void FmiVerboseLog(const char *format, ...)
+    void FmiVerboseLog(const char* format, ...)
     {
 #if defined(VERBOSE_FMI_LOGGING) && (defined(PRIVATE_LOG_PATH) || defined(PUBLIC_LOGGING))
         va_list ap;
@@ -119,7 +119,7 @@ class TraceFileWriter
     }
 
     /* Normal Logging */
-    void NormalLog(const char *category, const char *format, ...)
+    void NormalLog(const char* category, const char* format, ...)
     {
 #if defined(PRIVATE_LOG_PATH) || defined(PUBLIC_LOGGING)
         va_list ap;

--- a/src/modelDescription.in.xml
+++ b/src/modelDescription.in.xml
@@ -57,8 +57,11 @@
     <ScalarVariable name="custom_name" valueReference="2" causality="parameter" variability="fixed">
       <String start=""/>
     </ScalarVariable>
-    <ScalarVariable name="type" valueReference="3" causality="parameter" variability="fixed">
+    <ScalarVariable name="message_type" valueReference="3" causality="parameter" variability="fixed">
       <String start="sd"/>
+    </ScalarVariable>
+    <ScalarVariable name="file_format" valueReference="4" causality="parameter" variability="fixed">
+      <String start="osi"/>
     </ScalarVariable>
   </ModelVariables>
   <ModelStructure>


### PR DESCRIPTION
**Reference to a related issue in the repository**
Closes #15 

**Add a description**
Use [asam-osi-utilities](https://github.com/Lichtblick-Suite/asam-osi-utilities) to support writing to mcap, osi and txth trace files. 

- Uses the writers provided by asam-osi-utilities
- Supports more top-level message types than before
- To avoid branching and  handling the topic for MCAP, I’ve wrapped the writer function in a `std::function`.
- bumped OSI to 3.7.0
- used recursive github `actions/checkout` in recent `v4`

**Note:** I had also the idea to write the message without deserializing and implement something like a `writeSerializedMessage` into asam-osi-utilities but we need the timestamps for the MCAP anyways.

Why this should be kept in draft for now: 
- This links to a commit that is not yet merged in asam-osi-utilities, see https://github.com/Lichtblick-Suite/asam-osi-utilities/pull/12
- asam-osi-utilities always overrides the `osi_version` and `protobuf_version` fields of channel metadata. The automatic setting was intended as comfort function but it should if those fields are already present.

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://openmsl.github.io/doc/OpenMSL/organization/governance_rules.html).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] My changes generate no errors when passing CI tests. 
- [x] I updated all documentation (readmes incl. figures) according to my changes.
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

