### PR TITLE
20 add option to omit timestamp in file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ the [OSI Sensor Model Packaging (OSMP)](https://github.com/OpenSimulationInterfa
 
 ## FMI Parameters
 
-| Parameter        | Description                                                                                                                                                                                                                                                               |
-|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| trace_path       | Path, where to put the generated trace file                                                                                                                                                                                                                               |
+| Parameter       | Description                                                                                                                                                                                                                                                               |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| trace_path      | Path, where to put the generated trace file                                                                                                                                                                                                                               |
 | protobuf_version | Protobuf version, with which the OSI messages are serialized as string, e.g. "2112" for v21.12 (see [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html))                     |
-| custom_name      | Custom name as a suffix for the trace file name (see [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html))                                                                    |
-| message_type     | OSI message type string according to the [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html). <br>Currently supports: SensorData (sd), SensorView (sv), and GroundTruth (gt) |
-| file_format      | Format of the output trace file. Allowed values: mcap, osi, or txth                                                                                                                                                                                                       |
+| custom_name     | Custom name as a suffix for the trace file name (see [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html))                                                                    |
+| message_type    | OSI message type string according to the [Naming Convention](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/architecture/trace_file_naming.html). <br>Currently supports: SensorData (sd), SensorView (sv), and GroundTruth (gt) |
+| file_format     | Format of the output trace file. Allowed values: mcap, osi, or txth                                                                                                                                                                                                       |
+| omit_timestamp  | Bool to disable set of actual timestamp. If omit_timestamp is true, the timestamp is set to 00000000T000000Z.                                                                                                                                                             |
 
 ## Installation
 

--- a/src/OSMP.cpp
+++ b/src/OSMP.cpp
@@ -142,6 +142,8 @@ fmi2Status OSMP::DoInit()
         string_var = "";
     }
 
+    SetFmiOmitTimestamp(false);
+
     return fmi2OK;
 }
 
@@ -181,7 +183,7 @@ fmi2Status OSMP::DoExitInitializationMode()
         std::cerr << "Unknown trace file format: " << FmiFileFormat() << std::endl;
         return fmi2Error;
     }
-    trace_file_writer_.Init(FmiTracePath(), FmiProtobufVersion(), FmiCustomName(), FmiMessageType(), format_map_it->second);
+    trace_file_writer_.Init(FmiTracePath(), FmiProtobufVersion(), FmiCustomName(), FmiMessageType(), format_map_it->second, FmiOmitTimestamp());
 
     return fmi2OK;
 }

--- a/src/OSMP.h
+++ b/src/OSMP.h
@@ -39,7 +39,8 @@
 
 /* Boolean Variables */
 #define FMI_BOOLEAN_VALID_IDX 0
-#define FMI_BOOLEAN_LAST_IDX FMI_BOOLEAN_VALID_IDX
+#define FMI_BOOLEAN_OMIT_TIMESTAMP_IDX 1
+#define FMI_BOOLEAN_LAST_IDX FMI_BOOLEAN_OMIT_TIMESTAMP_IDX
 #define FMI_BOOLEAN_VARS (FMI_BOOLEAN_LAST_IDX + 1)
 
 /* Integer Variables */
@@ -220,6 +221,8 @@ class OSMP
     /* Simple Accessors */
     fmi2Boolean FmiValid() { return boolean_vars_[FMI_BOOLEAN_VALID_IDX]; }
     void SetFmiValid(fmi2Boolean value) { boolean_vars_[FMI_BOOLEAN_VALID_IDX] = value; }
+    fmi2Boolean FmiOmitTimestamp() { return boolean_vars_[FMI_BOOLEAN_OMIT_TIMESTAMP_IDX]; }
+    void SetFmiOmitTimestamp(fmi2Boolean value) { boolean_vars_[FMI_BOOLEAN_OMIT_TIMESTAMP_IDX] = value; }
     string FmiTracePath() { return string_vars_[FMI_STRING_TRACE_PATH_IDX]; }
     void SetFmiTracePath(string value) { string_vars_[FMI_STRING_TRACE_PATH_IDX] = value; }
     string FmiProtobufVersion() { return string_vars_[FMI_STRING_PROTOBUF_VERSION_IDX]; }

--- a/src/TraceFileWriter.cpp
+++ b/src/TraceFileWriter.cpp
@@ -18,8 +18,9 @@
 #include "osi_sensordata.pb.h"
 #include "osi_sensorview.pb.h"
 
-void TraceFileWriter::Init(const std::string& trace_path, std::string protobuf_version, std::string custom_name, std::string message_type, FileFormat file_format)
+void TraceFileWriter::Init(const std::string& trace_path, std::string protobuf_version, std::string custom_name, std::string message_type, FileFormat file_format, bool omit_timestamp)
 {
+    omit_timestamp_ = omit_timestamp;
     path_trace_folder_ = std::filesystem::path(trace_path);
     protobuf_version_ = std::move(protobuf_version);
     custom_name_ = std::move(custom_name);  // might be empty
@@ -43,7 +44,11 @@ void TraceFileWriter::SetFileName()
     time(&curr_time);
     const tm* date_time = localtime(&curr_time);
     strftime(buf, 20, "%Y%m%dT%H%M%SZ", date_time);
-    start_time_ = std::string(buf);
+    if (omit_timestamp_) {
+        start_time_ = "00000000T000000Z";
+    } else {
+        start_time_ = std::string(buf);
+    }
 
     auto trace_file_name = start_time_ + "_" + type_;
     if (!custom_name_.empty())

--- a/src/TraceFileWriter.h
+++ b/src/TraceFileWriter.h
@@ -24,7 +24,7 @@ enum class FileFormat : u_int8_t
 class TraceFileWriter
 {
   public:
-    void Init(const std::string& trace_path, std::string protobuf_version, std::string custom_name, std::string message_type, FileFormat file_format);
+    void Init(const std::string& trace_path, std::string protobuf_version, std::string custom_name, std::string message_type, FileFormat file_format, bool omit_timestamp);
     bool Step(const void* data, int size);
     void Term() const;
 
@@ -36,6 +36,7 @@ class TraceFileWriter
 
     std::filesystem::path path_trace_folder_;
     std::filesystem::path path_trace_temp_;
+    bool omit_timestamp_;
     std::string start_time_;
     int num_frames_ = 0;
     std::string osi_version_;

--- a/src/modelDescription.in.xml
+++ b/src/modelDescription.in.xml
@@ -48,6 +48,9 @@
     <ScalarVariable name="valid" valueReference="0" causality="output" variability="discrete" initial="exact">
       <Boolean start="false"/>
     </ScalarVariable>
+    <ScalarVariable name="omit_timestamp" valueReference="1" causality="parameter" variability="fixed">
+      <Boolean start="false"/>
+    </ScalarVariable>
     <ScalarVariable name="trace_path" valueReference="0" causality="parameter" variability="fixed">
       <String start=""/>
     </ScalarVariable>


### PR DESCRIPTION
**Reference to a related issue in the repository**
Solves https://github.com/openMSL/sl-5-6-osi-trace-file-writer/issues/20

**Add a description**
This MR adds a new Boolean FMI parameter omit_timestamp to the FMU, which changes the timestamp within the name. If omit_timestamp is true, the timestamp is set to 00000000T000000Z.

It is backwards compatible, because the default is set to false. 

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://openmsl.github.io/doc/OpenMSL/organization/governance_rules.html).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] My changes generate no errors when passing CI tests. 
- [x] I updated all documentation (readmes incl. figures) according to my changes.
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.

